### PR TITLE
fix: allow docker in docker for compose

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,6 +2,7 @@ services:
   test:
     image: maven:3.9.11-eclipse-temurin-21
     working_dir: /src
+    privileged: true
     volumes:
       - type: bind
         source: .
@@ -10,7 +11,18 @@ services:
       - type: volume
         source: maven-cache
         target: /root/.m2
-    entrypoint: ["mvn", "-Ptest", "clean", "verify", "-Dtest=**/*UnitTest", "-DfailIfNoTests=false", "--no-transfer-progress"]
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+    entrypoint:
+      [
+        "mvn",
+        "-Ptest",
+        "clean",
+        "test",
+        "-DfailIfNoTests=false",
+        "--no-transfer-progress",
+      ]
     container_name: dogwalks-unit-test
     environment:
       - SPRING_PROFILES_ACTIVE=test
@@ -18,6 +30,7 @@ services:
       - JWT_EXPIRATION=864000000
       - ADMIN_EMAIL=testadmin@test.com
       - ADMIN_PASSWORD=testAdminPsw547,
+      - TESTCONTAINERS_RYUK_DISABLED=true
     restart: no
 
 volumes:


### PR DESCRIPTION
This pull request updates the `docker-compose-test.yml` configuration to enhance the test container setup for running Maven-based unit tests. The most significant changes improve container permissions, allow Docker socket access, adjust the test command, and modify environment variables to support test execution.

**Container configuration improvements:**

* Added `privileged: true` to the `test` service to grant the container elevated permissions, which may be required for certain integration or system-level tests.
* Mounted the Docker socket (`/var/run/docker.sock`) into the container, enabling the test process to interact with Docker from within the container (e.g., for testcontainers or similar tools).

**Test execution adjustments:**

* Changed the Maven entrypoint command from `verify` with a specific test pattern to `test`, simplifying test execution and potentially broadening the scope of executed tests.

**Environment variable updates:**

* Added `TESTCONTAINERS_RYUK_DISABLED=true` to the environment, disabling Ryuk (the resource reaper) for testcontainers to avoid potential issues in CI or with Docker permissions.